### PR TITLE
Fix: Vue 2/3 lifecycle type errors and script tag cleanup

### DIFF
--- a/packages/vue2/src/google-translate-select.vue
+++ b/packages/vue2/src/google-translate-select.vue
@@ -118,6 +118,7 @@ export default Vue.extend<
       hoveredLanguageCode: '',
       setTimeoutId: -1,
       jsonCallbackFnName: '',
+      scriptTag: null,
       googleTranslateOriginSelectObserve: {},
       htmlAttrLangObserve: {},
       ns,
@@ -153,8 +154,17 @@ export default Vue.extend<
   },
   // @ts-ignore
   beforeUnmount() {
-    this.googleTranslateOriginSelectObserve!.stop!()
-    this.htmlAttrLangObserve!.stop!()
+    if (this.googleTranslateOriginSelectObserve?.stop) {
+      this.googleTranslateOriginSelectObserve!.stop!()
+    }
+
+    if (this.htmlAttrLangObserve?.stop) {
+      this.htmlAttrLangObserve!.stop!()
+    }
+
+    if (this.scriptTag?.unload) {
+      this.scriptTag.unload()
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const _this = this
@@ -220,7 +230,7 @@ export default Vue.extend<
     createGoogleTranslate() {
       this.createStyle()
       this.createJsonCallback()
-      this.createScript()
+      this.scriptTag = this.createScript()
     },
     /**
      * Triggers translations by observe changes in the DOM of GoogleTranslate's original select.

--- a/packages/vue3/src/google-translate-select.vue
+++ b/packages/vue3/src/google-translate-select.vue
@@ -441,8 +441,13 @@ export default defineComponent({
     })
 
     onBeforeUnmount(() => {
-      unref(googleTranslateOriginSelectObserve)!.stop!()
-      unref(htmlAttrLangObserve)!.stop!()
+      if (unref(googleTranslateOriginSelectObserve)?.stop) {
+        unref(googleTranslateOriginSelectObserve)!.stop!()
+      }
+
+      if (unref(htmlAttrLangObserve)?.stop) {
+        unref(htmlAttrLangObserve)!.stop!()
+      }
 
       if (props.trigger === 'click')
         document.removeEventListener('click', handleDropdownShowOrHideByClick)

--- a/packages/vue3/src/google-translate-select.vue
+++ b/packages/vue3/src/google-translate-select.vue
@@ -90,7 +90,10 @@ import {
 } from '@google-translate-select/constants'
 import '@google-translate-select/theme-chalk/src/index.scss'
 import { googleTranslateProps } from './types'
-import type { UseMutationObserverReturn } from '@google-translate-select/utils'
+import type {
+  CreateScriptTagReturn,
+  UseMutationObserverReturn,
+} from '@google-translate-select/utils'
 
 const ns = createNamespace('select')
 
@@ -106,6 +109,7 @@ export default defineComponent({
     const hoveredLanguageCode = ref<string>('')
     const setTimeoutId = ref<number>(-1)
     const jsonCallbackFnName = ref<string>('')
+    const scriptTag = ref<CreateScriptTagReturn | null>(null)
     const googleTranslateOriginSelectObserve =
       ref<Partial<UseMutationObserverReturn> | null>({})
     const htmlAttrLangObserve = ref<Partial<UseMutationObserverReturn> | null>(
@@ -178,7 +182,7 @@ export default defineComponent({
     function createGoogleTranslate() {
       createStyle()
       createJsonCallback()
-      createScript()
+      scriptTag.value = createScript()
     }
 
     /**
@@ -449,6 +453,9 @@ export default defineComponent({
         unref(htmlAttrLangObserve)!.stop!()
       }
 
+      if (unref(scriptTag)?.unload) {
+        unref(scriptTag)!.unload!()
+      }
       if (props.trigger === 'click')
         document.removeEventListener('click', handleDropdownShowOrHideByClick)
     })


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to @google-translate-select! ❤️🎉
For ease of review, please follow this template for your contribution.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR is to address a couple of bug issues: 

#73 
- `googleTranslateSelectObserve` and `htmlAttrLangObserve` are now checked for `null` during `onBeforeUnmount`. It looks like this is actually already done in the React package, so the Vue packages should be the same now.

 #78 
- The script tag from `createScript` is now removed in `onBeforeUnmount`. Then, when the page changes, a new script tag is inserted during `onMounted` and the script is run to reinject the `.goog-te-combo` element in the DOM. This ensures that the hidden `select` tag (`.goog-te-combo`) is present in between page loads in a SPA, for example.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Doesn't contain any sensitive information
